### PR TITLE
fix/footer-link-scroll-to-top

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,19 @@
 import { Coffee } from "lucide-react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom"; // Import useLocation
 
 export default function Footer() {
+  const location = useLocation();
+
+  const handleLinkClick = (e, path) => {
+    // If the user is already on the same page, prevent default link behavior
+    // and manually scroll to the top of the page.
+    if (location.pathname === path) {
+      e.preventDefault();
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+    // If it's a different page, the Link component will handle the navigation as normal.
+  };
+
   return (
     <footer className="bg-[#4A3728] text-white">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
@@ -16,16 +28,52 @@ export default function Footer() {
           <div className="flex flex-col md:flex-row items-center md:items-start gap-4 md:gap-8 text-sm w-full md:w-auto mt-4 md:mt-0">
             {/* Quick Links */}
             <div className="flex gap-4">
-              <Link to="/" className="text-gray-300 hover:text-white">Home</Link>
-              <Link to="/about" className="text-gray-300 hover:text-white">About</Link>
-              <Link to="/products" className="text-gray-300 hover:text-white">Products</Link>
-              <Link to="/contact" className="text-gray-300 hover:text-white">Contact</Link>
+              <Link
+                to="/"
+                className="text-gray-300 hover:text-white"
+                onClick={(e) => handleLinkClick(e, "/")}
+              >
+                Home
+              </Link>
+              <Link
+                to="/about"
+                className="text-gray-300 hover:text-white"
+                onClick={(e) => handleLinkClick(e, "/about")}
+              >
+                About
+              </Link>
+              <Link
+                to="/products"
+                className="text-gray-300 hover:text-white"
+                onClick={(e) => handleLinkClick(e, "/products")}
+              >
+                Products
+              </Link>
+              <Link
+                to="/contact"
+                className="text-gray-300 hover:text-white"
+                onClick={(e) => handleLinkClick(e, "/contact")}
+              >
+                Contact
+              </Link>
             </div>
 
             {/* Products - MODIFIED HERE */}
             <div className="hidden md:flex gap-4 border-t border-gray-600 pt-4 md:border-t-0 md:pt-0 md:border-l md:pl-6">
-              <Link to="/products" className="text-gray-300 hover:text-white">Arabica Premium</Link>
-              <Link to="/products" className="text-gray-300 hover:text-white">Robusta Select</Link>
+              <Link
+                to="/products"
+                className="text-gray-300 hover:text-white"
+                onClick={(e) => handleLinkClick(e, "/products")}
+              >
+                Arabica Premium
+              </Link>
+              <Link
+                to="/products"
+                className="text-gray-300 hover:text-white"
+                onClick={(e) => handleLinkClick(e, "/products")}
+              >
+                Robusta Select
+              </Link>
             </div>
           </div>
 


### PR DESCRIPTION
### PR Description
**Title:**
`fix: Add scroll-to-top functionality for footer links on current page`

**Description:**
This PR resolves an issue where clicking on a footer navigation link for the current page did not cause the page to scroll to the top. The previous behavior of the `react-router-dom` `Link` component prevented any action when the destination path was the same as the current one. This change improves user experience by allowing users to quickly return to the top of a long page by clicking the current page's link in the footer.

**Changes Made:**
- Imported the `useLocation` hook to get the current page's pathname.
- Added an `onClick` handler to each `Link` component in the footer.
- The `handleLinkClick` function checks if the `location.pathname` matches the link's `to` prop.
- If the paths are the same, `e.preventDefault()` is called to stop the default link behavior, and `window.scrollTo({ top: 0, behavior: 'smooth' })` is used to programmatically scroll the page to the top with a smooth animation.

